### PR TITLE
Whitespace is a delimeter so tab is also valid

### DIFF
--- a/jproperties.py
+++ b/jproperties.py
@@ -143,7 +143,7 @@ class Properties(object):
 			escaping = False
 			for c in s:
 				if not escaping:
-					if c in " :=":
+					if c in " \t:=":
 						return "".join(ret)
 					elif c == "\\":
 						escaping = True
@@ -156,7 +156,7 @@ class Properties(object):
 		def getseparator(s):
 			ret = []
 			for c in s:
-				if c not in " :=":
+				if c not in " \t:=":
 					return "".join(ret)
 				ret.append(c)
 			return "".join(ret)

--- a/test_main.py
+++ b/test_main.py
@@ -33,6 +33,7 @@ def test_space_separator():
 		("a b", [("a", "b")]),
 		("a  b", [("a", "b")]),
 		("a        b", [("a", "b")]),
+		("a\tb", [("a", "b")]),  # Tab is also a valid separator
 	)
 
 


### PR DESCRIPTION
Tested this with Java properties file, \t is valid.  I'm not sure what other whitespace would be considered valid.
