### PR TITLE
Updating Property node instead of append new if key already exists

### DIFF
--- a/jproperties.py
+++ b/jproperties.py
@@ -56,13 +56,21 @@ class Properties(object):
 				ret.append(self.escape_key(node.key) + node.separator + self.escape(node.value))
 		return "\n".join(ret)
 
-	def __getitem__(self, name):
+	def __getitem__(self, key):
 		return self._props.get(key, "")
 	getProperty = __getitem__
 
 	def __setitem__(self, key, value):
 		self._props[key] = value
-		self.nodes.append(Property(key, value))
+		property_found = False
+		for node in self.nodes:
+			if isinstance(node, Property) and node.key == key:
+				index = self.nodes.index(node)
+				self.nodes.insert(index, Property(key, value))
+				self.nodes.remove(node)
+				property_found = True
+		if not property_found:
+			self.nodes.append(Property(key, value))
 	setProperty = __setitem__
 
 	@staticmethod

--- a/test_main.py
+++ b/test_main.py
@@ -113,6 +113,7 @@ def test_separator_in_key():
 		([("key\twith\ttabs", "b")], r"key\twith\ttabs = b"),
 	)
 
+
 def test_space_in_key():
 	_test_deserialize(
 		("key\ with\ spaces = b", [("key with spaces", "b")]),
@@ -120,6 +121,14 @@ def test_space_in_key():
 		("key\ with\ spaces : b", [("key with spaces", "b")]),
 		("key\ with\ spaces\ : b", [("key with spaces ", "b")]),
 	)
+
+
+def test_property_node_update():
+	s = "key = value"
+	props = Properties()
+	props.load(StringIO(s))
+	props['key'] = 'another_value'
+	assert str(props) == "key = another_value"
 
 
 def main():


### PR DESCRIPTION
In case of setting property which originally was in property file, Property node will be replaced with new value.
